### PR TITLE
Take `type` slot into account, and modularize the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ graph LR
     script --> violations
 ```
 
+## Assumptions
+
+`refscan` was designed under some assumptions about the user's schema and database, including:
+
+1. Each source document (i.e. document containing references) has a field named `type`, whose value (a string) is the [class_uri](https://linkml.io/linkml/code/metamodel.html#linkml_runtime.linkml_model.meta.ClassDefinition.class_uri) of the schema class of which the document represents an instance. For example, the `type` field of each document in the `study_set` collection has the value `"nmdc:Study"`. 
+
 ## Development status
 
 `refscan` is in early development and its author does not recommend anyone use it for anything.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ graph LR
 ## Development status
 
 `refscan` is in early development and its author does not recommend anyone use it for anything.
+
+The main algorithm in `refscan/refscan.py` is overdue for cleanup and optimization. The original algorithm was based
+upon fewer assumptions about the schema and database than the current one (see "Assumptions" section above).
+Parts of the current algorithm may be unnecessarily convoluted as a result.

--- a/refscan/lib/Reference.py
+++ b/refscan/lib/Reference.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, order=True)
+class Reference:
+    """
+    A generic reference to a document in a collection.
+
+    Note: `frozen` means the instances are immutable.
+    Note: `order` means the instances have methods that help with sorting. For example, an `__eq__` method that
+          can be used to compare instances of the class as thought they were tuples of those instances' fields.
+    """
+    source_collection_name: str = field()  # e.g. "study_set"
+    source_class_name: str = field()  # e.g. "Study"
+    source_field_name: str = field()  # e.g. "part_of"
+    target_collection_name: str = field()  # e.g. "study_set" (reminder: a study can be part of another study)
+    target_class_name: str = field()  # e.g. "Study"

--- a/refscan/lib/ReferenceList.py
+++ b/refscan/lib/ReferenceList.py
@@ -38,30 +38,19 @@ class ReferenceList(UserList):
 
     def get_target_collection_names(
             self,
-            source_collection_name: str,
+            source_class_name: str,
             source_field_name: str,
-            source_class_name: str | None = None,
     ) -> list[str]:
         """
-        Returns a list of the names of the collections in which the document referenced by the given field may exist.
+        Returns a list of the names of the collections in which a [target] document referenced by the specified field
+        of a [source] document representing an instance of the specified schema class, might exist.
         """
         distinct_target_collection_names = []
         references = self.data  # note: in a `UserList`, `self.data` refers to the underlying list data structure
         for reference in references:
 
-            # Check whether this reference's source class matches the one specified, if any was specified.
-            #
-            # TODO: I defaulted to `True` here so as to avoid affecting existing behavior (for better or for worse).
-            #       I may change that once any calling code gets updated to pass in the `source_class_name` value.
-            #
-            reference_class_matches_source_class = True
-            if source_class_name is not None:
-                reference_class_matches_source_class = reference.source_class_name == source_class_name
-
             # If this reference's source describes the specified source, record the reference's target collection name.
-            if reference.source_collection_name == source_collection_name and \
-                    reference.source_field_name == source_field_name and \
-                    reference_class_matches_source_class:
+            if reference.source_field_name == source_field_name and reference.source_class_name == source_class_name:
                 if reference.target_collection_name not in distinct_target_collection_names:  # avoids duplicates
                     distinct_target_collection_names.append(reference.target_collection_name)
 

--- a/refscan/lib/ReferenceList.py
+++ b/refscan/lib/ReferenceList.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+from dataclasses import fields, astuple
+from collections import UserList
+from itertools import groupby
+import csv
+
+from refscan.lib.Reference import Reference
+
+
+class ReferenceList(UserList):
+    """
+    A list of references.
+
+    Note: `UserList` is a base class that facilitates the implementation of custom list classes.
+          One thing it does is enable sorting via `sorted(the_list)`.
+    """
+
+    def get_source_collection_names(self) -> list[str]:
+        """
+        Returns the distinct `source_collection_names` values among all references in the list.
+        """
+        distinct_source_collection_names = []
+        for reference in self.data:
+            if reference.source_collection_name not in distinct_source_collection_names:
+                distinct_source_collection_names.append(reference.source_collection_name)
+        return distinct_source_collection_names
+
+    def get_source_field_names_of_source_collection(self, collection_name: str) -> list[str]:
+        """
+        Returns the distinct source field names of the specified source collection.
+        """
+        distinct_source_field_names = []
+        for reference in self.data:
+            if reference.source_collection_name == collection_name:
+                if reference.source_field_name not in distinct_source_field_names:
+                    distinct_source_field_names.append(reference.source_field_name)
+        return distinct_source_field_names
+
+    def get_target_collection_names(
+            self,
+            source_collection_name: str,
+            source_field_name: str,
+            source_class_name: str | None = None,
+    ) -> list[str]:
+        """
+        Returns a list of the names of the collections in which the document referenced by the given field may exist.
+        """
+        distinct_target_collection_names = []
+        references = self.data  # note: in a `UserList`, `self.data` refers to the underlying list data structure
+        for reference in references:
+
+            # Check whether this reference's source class matches the one specified, if any was specified.
+            #
+            # TODO: I defaulted to `True` here so as to avoid affecting existing behavior (for better or for worse).
+            #       I may change that once any calling code gets updated to pass in the `source_class_name` value.
+            #
+            reference_class_matches_source_class = True
+            if source_class_name is not None:
+                reference_class_matches_source_class = reference.source_class_name == source_class_name
+
+            # If this reference's source describes the specified source, record the reference's target collection name.
+            if reference.source_collection_name == source_collection_name and \
+                    reference.source_field_name == source_field_name and \
+                    reference_class_matches_source_class:
+                if reference.target_collection_name not in distinct_target_collection_names:  # avoids duplicates
+                    distinct_target_collection_names.append(reference.target_collection_name)
+
+        return distinct_target_collection_names
+
+    def get_groups(self, field_names: list[str]) -> list[tuple[str, str, str, str, list[str]]]:
+        r"""
+        Returns an iterable of groups, where each group has a distinct combination of values in the specified fields.
+
+        Note: This method can be used to "consolidate" references that have the same source collection name,
+              source field name, and target collection name (i.e. ones that only differ by target class name).
+        """
+
+        def make_group_key(reference: Reference) -> tuple:
+            """Helper function that returns a key that can be used to group references."""
+            values = []
+            for field_name in field_names:
+                if not hasattr(reference, field_name):
+                    raise ValueError(f"No such field: {field_name}")
+                values.append(getattr(reference, field_name))
+            return tuple(values)
+
+        groups = groupby(sorted(self.data), key=make_group_key)
+        return groups
+
+    def dump_to_tsv_file(self, file_path: str | Path) -> None:
+        r"""
+        Helper function that dumps the references to a TSV file at the specified path.
+        """
+        column_names = [field_.name for field_ in fields(Reference)]
+        with open(file_path, "w", newline="") as tsv_file:
+            writer = csv.writer(tsv_file, delimiter="\t")
+            writer.writerow(column_names)  # header row
+            for reference in self.data:
+                writer.writerow(astuple(reference))  # data row

--- a/refscan/lib/ReferenceList.py
+++ b/refscan/lib/ReferenceList.py
@@ -24,11 +24,15 @@ class ReferenceList(UserList):
         Note: We define this method so that instances of this class are hashable, which allows us to use
               the `@cache` decorator (from `functools`) on methods of this class.
 
+        TODO: Do benchmarking to check whether hashing via `tuple(self.data)` is faster or slower than manually
+              hashing each string in each row of `self.data` and hashing the combination of those hashes.
+
         Reference: https://docs.python.org/3.10/reference/datamodel.html#object.__hash__
         """
         data_as_tuple = tuple(self.data)
         return hash(data_as_tuple)
 
+    @cache
     def get_source_collection_names(self) -> list[str]:
         """
         Returns the distinct `source_collection_names` values among all references in the list.
@@ -39,6 +43,7 @@ class ReferenceList(UserList):
                 distinct_source_collection_names.append(reference.source_collection_name)
         return distinct_source_collection_names
 
+    @cache
     def get_source_field_names_of_source_collection(self, collection_name: str) -> list[str]:
         """
         Returns the distinct source field names of the specified source collection.
@@ -50,6 +55,7 @@ class ReferenceList(UserList):
                     distinct_source_field_names.append(reference.source_field_name)
         return distinct_source_field_names
 
+    @cache
     def get_target_collection_names(
             self,
             source_class_name: str,

--- a/refscan/lib/Violation.py
+++ b/refscan/lib/Violation.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, order=True)
+class Violation:
+    """
+    A specific reference that lacks integrity.
+    """
+    source_collection_name: str = field()
+    source_field_name: str = field()
+    source_document_object_id: str = field()
+    source_document_id: str = field()
+    target_id: str = field()

--- a/refscan/lib/ViolationList.py
+++ b/refscan/lib/ViolationList.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from dataclasses import fields, astuple
+from collections import UserList
+import csv
+
+from refscan.lib.Violation import Violation
+
+
+class ViolationList(UserList):
+    """
+    A list of violations.
+    """
+
+    def dump_to_tsv_file(self, file_path: str | Path) -> None:
+        """
+        Helper function that dumps the violations to a TSV file at the specified path.
+        """
+        column_names = [field_.name for field_ in fields(Violation)]
+        with open(file_path, "w", newline="") as tsv_file:
+            writer = csv.writer(tsv_file, delimiter="\t")
+            writer.writerow(column_names)  # header row
+            for violation in self.data:
+                writer.writerow(astuple(violation))  # data row

--- a/refscan/lib/constants.py
+++ b/refscan/lib/constants.py
@@ -1,0 +1,8 @@
+from rich.console import Console
+
+# Instantiate a Rich console for fancy console output.
+# Reference: https://rich.readthedocs.io/en/stable/console.html
+console = Console()
+
+# Note: This is the only schema class name hard-coded into this script.
+DATABASE_CLASS_NAME = "Database"

--- a/refscan/lib/helpers.py
+++ b/refscan/lib/helpers.py
@@ -1,3 +1,6 @@
+from typing import Optional
+from functools import cache
+
 from pymongo import MongoClient, timeout
 from pymongo.database import Database
 from linkml_runtime import SchemaView
@@ -106,3 +109,38 @@ def check_whether_document_having_id_exists_among_collections(
         if document_exists:  # if we found the document in this collection, there is no need to keep searching
             break
     return document_exists
+
+
+@cache  # memoizes the decorated function
+def translate_class_uri_into_schema_class_name(schema_view: SchemaView, class_uri: str) -> Optional[str]:
+    r"""
+    Returns the name of the schema class that has the specified value as its `class_uri`.
+
+    Example `"nmdc:Biosample" (a `class_uri` value) -> "Biosample" (a class name)
+
+    References:
+    - https://linkml.io/linkml/developers/schemaview.html#linkml_runtime.utils.schemaview.SchemaView.all_classes
+    - https://linkml.io/linkml/code/metamodel.html#linkml_runtime.linkml_model.meta.ClassDefinition.class_uri
+    """
+    schema_class_name = None
+    all_class_definitions_in_schema = schema_view.all_classes()
+    for class_name, class_definition in all_class_definitions_in_schema.items():
+        if class_definition.class_uri == class_uri:
+            schema_class_name = class_definition.name
+            break
+    return schema_class_name
+
+
+def derive_schema_class_name_from_document(schema_view: SchemaView, document: dict) -> Optional[str]:
+    r"""
+    Returns the name of the schema class, if any, of which the specified document claims to represent an instance.
+
+    This function is written under the assumption that the document has a `type` field whose value is the `class_uri`
+    belonging to the schema class of which the document represents an instance. Slot definition for such a field:
+    https://github.com/microbiomedata/berkeley-schema-fy24/blob/fc2d9600/src/schema/basic_slots.yaml#L420-L436
+    """
+    schema_class_name = None
+    if "type" in document and isinstance(document["type"], str):
+        class_uri = document["type"]
+        schema_class_name = translate_class_uri_into_schema_class_name(schema_view, class_uri)
+    return schema_class_name

--- a/refscan/lib/helpers.py
+++ b/refscan/lib/helpers.py
@@ -1,0 +1,108 @@
+from pymongo import MongoClient, timeout
+from pymongo.database import Database
+from linkml_runtime import SchemaView
+
+from refscan.lib.constants import DATABASE_CLASS_NAME, console
+
+
+def connect_to_database(mongo_uri: str, database_name: str, verbose: bool = True) -> MongoClient:
+    """
+    Returns a Mongo client. Raises an exception if the database is not accessible.
+    """
+    mongo_client: MongoClient = MongoClient(host=mongo_uri, directConnection=True)
+
+    with (timeout(5)):  # if any message exchange takes > 5 seconds, this will raise an exception
+        (host, port_number) = mongo_client.address
+
+        if verbose:
+            console.print(f'Connected to MongoDB server: "{host}:{port_number}"')
+
+        # Check whether the database exists on the MongoDB server.
+        if database_name not in mongo_client.list_database_names():
+            raise ValueError(f'Database "{database_name}" not found on the MongoDB server.')
+
+    return mongo_client
+
+
+def get_collection_names_from_database(
+        mongo_client: MongoClient,
+        database_name: str,
+        verbose: bool = True
+) -> list[str]:
+    """
+    Returns the names of the collections that exist in the specified database.
+    """
+    db = mongo_client.get_database(database_name)
+    collection_names = db.list_collection_names()
+
+    if verbose:
+        console.print(f"Existing collections: {len(collection_names)}")
+
+    return collection_names
+
+
+def get_collection_names_from_schema(
+        schema_view: SchemaView,
+        verbose: bool = True
+) -> list[str]:
+    """
+    Returns the names of the slots of the `Database` class that correspond to database collections.
+
+    :param schema_view: A `SchemaView` instance
+    :param verbose: Whether to show verbose output
+    """
+    collection_names = []
+
+    for slot_name in schema_view.class_slots(DATABASE_CLASS_NAME):
+        slot_definition = schema_view.induced_slot(slot_name, DATABASE_CLASS_NAME)
+
+        # Filter out any hypothetical (future) slots that don't correspond to a collection (e.g. `db_version`).
+        if slot_definition.multivalued and slot_definition.inlined_as_list:
+            collection_names.append(slot_name)
+
+        # Filter out duplicate names. This is to work around the following issues in the schema:
+        # - https://github.com/microbiomedata/nmdc-schema/issues/1954
+        # - https://github.com/microbiomedata/nmdc-schema/issues/1955
+        collection_names = list(set(collection_names))
+
+    if verbose:
+        console.print(f"Collections described by schema: {len(collection_names)}")
+
+    return collection_names
+
+
+def get_common_values(list_a: list, list_b: list) -> list:
+    """
+    Returns only the items that are present in _both_ lists.
+
+    >>> get_common_values([1, 2, 3], [4, 5])  # zero
+    []
+    >>> get_common_values([1, 2, 3], [3, 4, 5])  # one
+    [3]
+    >>> get_common_values([1, 2, 3, 4], [3, 4])  # multiple
+    [3, 4]
+    >>> get_common_values([1, 2, 3], [1, 2, 3])  # all
+    [1, 2, 3]
+    """
+    return [a for a in list_a if a in list_b]
+
+
+def check_whether_document_having_id_exists_among_collections(
+        db: Database,
+        collection_names: list[str],
+        document_id: str
+) -> bool:
+    """
+    Checks whether any documents having the specified `id` value (in its `id` field) exists
+    in any of the specified collections.
+
+    References:
+    - https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.find_one
+    """
+    document_exists = False
+    query_filter = {"id": document_id}
+    for collection_name in collection_names:
+        document_exists = db.get_collection(collection_name).find_one(query_filter, projection=["_id"]) is not None
+        if document_exists:  # if we found the document in this collection, there is no need to keep searching
+            break
+    return document_exists

--- a/refscan/refscan.py
+++ b/refscan/refscan.py
@@ -1,13 +1,8 @@
 from pathlib import Path
 from typing import List, Optional
 from typing_extensions import Annotated
-from dataclasses import dataclass, field, fields, astuple
-from collections import UserList
-from itertools import groupby
-import csv
 
 import typer
-from rich.console import Console
 from rich.table import Table, Column
 from rich.progress import (
     BarColumn,
@@ -17,262 +12,26 @@ from rich.progress import (
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
-from pymongo import MongoClient, timeout
-from pymongo.database import Database
 from linkml_runtime import SchemaView
+
+from refscan.lib.constants import DATABASE_CLASS_NAME, console
+from refscan.lib.helpers import (
+    connect_to_database,
+    get_collection_names_from_database,
+    get_collection_names_from_schema,
+    get_common_values,
+    check_whether_document_having_id_exists_among_collections
+)
+from refscan.lib.Reference import Reference
+from refscan.lib.ReferenceList import ReferenceList
+from refscan.lib.Violation import Violation
+from refscan.lib.ViolationList import ViolationList
 
 app = typer.Typer(
     help="Scan the NMDC MongoDB database for referential integrity violations.",
     add_completion=False,  # hides the shell completion options from `--help` output
     rich_markup_mode="markdown",  # enables use of Markdown in docstrings and CLI help
 )
-
-# Instantiate a Rich console for fancy console output.
-# Reference: https://rich.readthedocs.io/en/stable/console.html
-console = Console()
-
-# Note: This is the only schema class name hard-coded into this script.
-DATABASE_CLASS_NAME = "Database"
-
-
-def connect_to_database(mongo_uri: str, database_name: str, verbose: bool = True) -> MongoClient:
-    """
-    Returns a Mongo client. Raises an exception if the database is not accessible.
-    """
-    mongo_client: MongoClient = MongoClient(host=mongo_uri, directConnection=True)
-
-    with (timeout(5)):  # if any message exchange takes > 5 seconds, this will raise an exception
-        (host, port_number) = mongo_client.address
-
-        if verbose:
-            console.print(f'Connected to MongoDB server: "{host}:{port_number}"')
-
-        # Check whether the database exists on the MongoDB server.
-        if database_name not in mongo_client.list_database_names():
-            raise ValueError(f'Database "{database_name}" not found on the MongoDB server.')
-
-    return mongo_client
-
-
-def get_collection_names_from_database(
-        mongo_client: MongoClient,
-        database_name: str,
-        verbose: bool = True
-) -> list[str]:
-    """
-    Returns the names of the collections that exist in the specified database.
-    """
-    db = mongo_client.get_database(database_name)
-    collection_names = db.list_collection_names()
-
-    if verbose:
-        console.print(f"Existing collections: {len(collection_names)}")
-
-    return collection_names
-
-
-def get_collection_names_from_schema(
-        schema_view: SchemaView,
-        verbose: bool = True
-) -> list[str]:
-    """
-    Returns the names of the slots of the `Database` class that correspond to database collections.
-
-    :param schema_view: A `SchemaView` instance
-    :param verbose: Whether to show verbose output
-    """
-    collection_names = []
-
-    for slot_name in schema_view.class_slots(DATABASE_CLASS_NAME):
-        slot_definition = schema_view.induced_slot(slot_name, DATABASE_CLASS_NAME)
-
-        # Filter out any hypothetical (future) slots that don't correspond to a collection (e.g. `db_version`).
-        if slot_definition.multivalued and slot_definition.inlined_as_list:
-            collection_names.append(slot_name)
-
-        # Filter out duplicate names. This is to work around the following issues in the schema:
-        # - https://github.com/microbiomedata/nmdc-schema/issues/1954
-        # - https://github.com/microbiomedata/nmdc-schema/issues/1955
-        collection_names = list(set(collection_names))
-
-    if verbose:
-        console.print(f"Collections described by schema: {len(collection_names)}")
-
-    return collection_names
-
-
-def get_common_values(list_a: list, list_b: list) -> list:
-    """
-    Returns only the items that are present in _both_ lists.
-
-    >>> get_common_values([1, 2, 3], [4, 5])  # zero
-    []
-    >>> get_common_values([1, 2, 3], [3, 4, 5])  # one
-    [3]
-    >>> get_common_values([1, 2, 3, 4], [3, 4])  # multiple
-    [3, 4]
-    >>> get_common_values([1, 2, 3], [1, 2, 3])  # all
-    [1, 2, 3]
-    """
-    return [a for a in list_a if a in list_b]
-
-
-@dataclass(frozen=True, order=True)
-class Violation:
-    """
-    A specific reference that lacks integrity.
-    """
-    source_collection_name: str = field()
-    source_field_name: str = field()
-    source_document_object_id: str = field()
-    source_document_id: str = field()
-    target_id: str = field()
-
-
-class ViolationList(UserList):
-    """
-    A list of violations.
-    """
-
-    def dump_to_tsv_file(self, file_path: str | Path) -> None:
-        """
-        Helper function that dumps the violations to a TSV file at the specified path.
-        """
-        column_names = [field_.name for field_ in fields(Violation)]
-        with open(file_path, "w", newline="") as tsv_file:
-            writer = csv.writer(tsv_file, delimiter="\t")
-            writer.writerow(column_names)  # header row
-            for violation in self.data:
-                writer.writerow(astuple(violation))  # data row
-
-
-@dataclass(frozen=True, order=True)
-class Reference:
-    """
-    A generic reference to a document in a collection.
-
-    Note: `frozen` means the instances are immutable.
-    Note: `order` means the instances have methods that help with sorting. For example, an `__eq__` method that
-          can be used to compare instances of the class as thought they were tuples of those instances' fields.
-    """
-    source_collection_name: str = field()  # e.g. "study_set"
-    source_class_name: str = field()  # e.g. "Study"
-    source_field_name: str = field()  # e.g. "part_of"
-    target_collection_name: str = field()  # e.g. "study_set" (reminder: a study can be part of another study)
-    target_class_name: str = field()  # e.g. "Study"
-
-
-class ReferenceList(UserList):
-    """
-    A list of references.
-
-    Note: `UserList` is a base class that facilitates the implementation of custom list classes.
-          One thing it does is enable sorting via `sorted(the_list)`.
-    """
-
-    def get_source_collection_names(self) -> list[str]:
-        """
-        Returns the distinct `source_collection_names` values among all references in the list.
-        """
-        distinct_source_collection_names = []
-        for reference in self.data:
-            if reference.source_collection_name not in distinct_source_collection_names:
-                distinct_source_collection_names.append(reference.source_collection_name)
-        return distinct_source_collection_names
-
-    def get_source_field_names_of_source_collection(self, collection_name: str) -> list[str]:
-        """
-        Returns the distinct source field names of the specified source collection.
-        """
-        distinct_source_field_names = []
-        for reference in self.data:
-            if reference.source_collection_name == collection_name:
-                if reference.source_field_name not in distinct_source_field_names:
-                    distinct_source_field_names.append(reference.source_field_name)
-        return distinct_source_field_names
-
-    def get_target_collection_names(
-            self,
-            source_collection_name: str,
-            source_field_name: str,
-            source_class_name: str | None = None,
-    ) -> list[str]:
-        """
-        Returns a list of the names of the collections in which the document referenced by the given field may exist.
-        """
-        distinct_target_collection_names = []
-        references = self.data  # note: in a `UserList`, `self.data` refers to the underlying list data structure
-        for reference in references:
-
-            # Check whether this reference's source class matches the one specified, if any was specified.
-            #
-            # TODO: I defaulted to `True` here so as to avoid affecting existing behavior (for better or for worse).
-            #       I may change that once any calling code gets updated to pass in the `source_class_name` value.
-            #
-            reference_class_matches_source_class = True
-            if source_class_name is not None:
-                reference_class_matches_source_class = reference.source_class_name == source_class_name
-
-            # If this reference's source describes the specified source, record the reference's target collection name.
-            if reference.source_collection_name == source_collection_name and \
-                    reference.source_field_name == source_field_name and \
-                    reference_class_matches_source_class:
-                if reference.target_collection_name not in distinct_target_collection_names:  # avoids duplicates
-                    distinct_target_collection_names.append(reference.target_collection_name)
-
-        return distinct_target_collection_names
-
-    def get_groups(self, field_names: list[str]) -> list[tuple[str, str, str, str, list[str]]]:
-        r"""
-        Returns an iterable of groups, where each group has a distinct combination of values in the specified fields.
-
-        Note: This method can be used to "consolidate" references that have the same source collection name,
-              source field name, and target collection name (i.e. ones that only differ by target class name).
-        """
-
-        def make_group_key(reference: Reference) -> tuple:
-            """Helper function that returns a key that can be used to group references."""
-            values = []
-            for field_name in field_names:
-                if not hasattr(reference, field_name):
-                    raise ValueError(f"No such field: {field_name}")
-                values.append(getattr(reference, field_name))
-            return tuple(values)
-
-        groups = groupby(sorted(self.data), key=make_group_key)
-        return groups
-
-    def dump_to_tsv_file(self, file_path: str | Path) -> None:
-        r"""
-        Helper function that dumps the references to a TSV file at the specified path.
-        """
-        column_names = [field_.name for field_ in fields(Reference)]
-        with open(file_path, "w", newline="") as tsv_file:
-            writer = csv.writer(tsv_file, delimiter="\t")
-            writer.writerow(column_names)  # header row
-            for reference in self.data:
-                writer.writerow(astuple(reference))  # data row
-
-
-def check_whether_document_having_id_exists_among_collections(
-        db: Database,
-        collection_names: list[str],
-        document_id: str
-) -> bool:
-    """
-    Checks whether any documents having the specified `id` value (in its `id` field) exists
-    in any of the specified collections.
-
-    References:
-    - https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.find_one
-    """
-    document_exists = False
-    query_filter = {"id": document_id}
-    for collection_name in collection_names:
-        document_exists = db.get_collection(collection_name).find_one(query_filter, projection=["_id"]) is not None
-        if document_exists:  # if we found the document in this collection, there is no need to keep searching
-            break
-    return document_exists
 
 
 @app.command("scan")

--- a/refscan/refscan.py
+++ b/refscan/refscan.py
@@ -272,8 +272,11 @@ def scan(
                 # Get the document's schema class name so that we can interpret its fields accordingly.
                 source_class_name = derive_schema_class_name_from_document(schema_view, document)
 
-                # Check each field that — in documents in this collection — can contain a reference.
-                for field_name in source_field_names:
+                # Get the names of that class's fields that can contain references.
+                names_of_reference_fields = references.get_reference_field_names_for_class(source_class_name)
+
+                # Check each field that both (a) exists in the document and (b) can contain a reference.
+                for field_name in names_of_reference_fields:
                     if field_name in document:
                         # Determine which collections can contain the referenced document, based upon
                         # the schema class of which this source document is an instance.

--- a/refscan/refscan.py
+++ b/refscan/refscan.py
@@ -258,11 +258,6 @@ def scan(
             # Process each relevant document.
             for document in collection.find(query_filter, projection=query_projection):
 
-                # Advance the progress bar to account for the current document.
-                progress.update(task_id,
-                                advance=1,
-                                num_violations=len(source_collections_and_their_violations[source_collection_name]))
-
                 # Get the document's `id` so that we can include it in this script's output.
                 source_document_object_id = document["_id"]
                 source_document_id = document["id"] if "id" in document else None
@@ -317,6 +312,11 @@ def scan(
                                     console.print(f"Failed to find document having `id` '{target_id}' "
                                                   f"among collections: {target_collection_names}. "
                                                   f"{violation=}")
+
+                # Advance the progress bar to account for the current document's contribution to the violations count.
+                progress.update(task_id,
+                                advance=1,
+                                num_violations=len(source_collections_and_their_violations[source_collection_name]))
 
             # Update the progress bar to indicate the current task is complete.
             progress.update(task_id, remaining_time_label="done")


### PR DESCRIPTION
In this branch, I did three things (I would normally do these on three separate branches):
1. [Refactor: Extract class/function definitions into separate modules](https://github.com/eecavanna/refscan/commit/628e52956fd55e6584af21389966760dafe367f8)
2. [Fix logical bug where source document's type was not taken into account](https://github.com/eecavanna/refscan/commit/9197c1265fc87f37d88aa0c3164eb99b768ba002)
3. [Cache the output of several `ReferenceList` methods](https://github.com/eecavanna/refscan/pull/1/commits/53bf308d13c79d2b8bf05d6e69b9bb079d1df454)